### PR TITLE
fix issue with isreg detection

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -56,11 +56,6 @@
     - php_symlink_scl_bins
     - item.isreg
 
-- name: Stat PHP.ini
-  stat:
-    path="/etc/php.ini"
-  register: phpini
-
 - name: Symlink PHP.ini
   file:
     src="{{ php_config_root }}/php.ini"
@@ -69,10 +64,8 @@
     group="root"
     mode="0644"
     state="link"
-    force="{{ phpini.stat.isreg }}"
-  when: 
-    - php_single_version 
-    - phpini.stat.isreg
+    force=true
+  when: php_single_version
 
 - name: Tweak PHP.ini Vars
   ini_file:


### PR DESCRIPTION
I'm guessing when stat on a non-existant file is set, the dict doesn't populate which causes errors like:

```
TASK [nexcess.php : Symlink PHP.ini] *******************************************
fatal: [localhost]: FAILED! => {"failed": true, "msg": "The conditional check 'phpini.stat.isreg' failed. The error was: error while evaluating conditional (phpini.stat.isreg): 'dict object' has no attribute 'isreg'\n\nThe error appears to have been in '/etc/ansible/roles/nexcess.php/tasks/main.yml': line 64, column 3, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n\n- name: Symlink PHP.ini\n  ^ here\n"}
```
Currently role fails to apply because of this.