### PR TITLE
Revert "enforce symlink creation idempotentency"

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -50,16 +50,8 @@
     group="root"
     mode="0755"
     state="link"
-    force="{{ item.isreg }}"
   with_items: "{{ found.files }}"
-  when: 
-    - php_symlink_scl_bins
-    - item.isreg
-
-- name: Stat PHP.ini
-  stat:
-    path="/etc/php.ini"
-  register: phpini
+  when: php_symlink_scl_bins
 
 - name: Symlink PHP.ini
   file:
@@ -69,10 +61,7 @@
     group="root"
     mode="0644"
     state="link"
-    force="{{ phpini.stat.isreg }}"
-  when: 
-    - php_single_version 
-    - phpini.stat.isreg
+  when: php_single_version == true
 
 - name: Tweak PHP.ini Vars
   ini_file:


### PR DESCRIPTION
This reverts commit 8ae2f2ea9d7df6596ee6453b4c4c5b11609b023b.