### PR TITLE
Don't install php-devel packages

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -16,7 +16,6 @@ php_base_packages:
   - "php-intl"
   - "php-tidy"
   - "php-imap"
-  - "php-devel"
   - "php-xmlrpc"
   - "php-mcrypt"
   - "php-common"


### PR DESCRIPTION
The packages from REMI currently depend on packages not in REMI or other default repos.

```
Error: Package: php71-php-devel-7.1.15-1.el7.remi.x86_64 (remi-safe)\n           Requires: devtoolset-6-gcc-c++\n"
```

the -devel packages are needed only for building php extensions, not something that is needed by default IMO.