### PR TITLE
add PHP 8.5 for EL9

### DIFF
--- a/nexcess-php-meta/changelog.txt
+++ b/nexcess-php-meta/changelog.txt
@@ -1,2 +1,4 @@
+*Thu Jun 25 2026 Chris Orlando <chrsorlando@gmail.com> - 2026.6.25-01
+- Add support for PHP 8.5.
 *Mon Jan 26 2026 James Coleman <james.coleman@liquidweb.com> - 2026.1.26-01
 - Initial build

--- a/nexcess-php-meta/config.yaml
+++ b/nexcess-php-meta/config.yaml
@@ -19,6 +19,7 @@ php_versions:
   - "php82"
   - "php83"
   - "php84"
+  - "php85"
 php_base_packages:
   - "php-bcmath"
   - "php-brotli"
@@ -177,6 +178,13 @@ php83_specific_packages:
   - "php-pecl-geoip"
   - "php-pecl-redis5"
 php84_specific_packages:
+  - "php-ast"
+  - "php-json"
+  - "php-sodium"
+  - "php-pecl-igbinary"
+  - "php-pecl-geoip"
+  - "php-pecl-redis5"
+php85_specific_packages:
   - "php-ast"
   - "php-json"
   - "php-sodium"


### PR DESCRIPTION
Adds support for PHP 8.5 meta packages on EL9.

- Add `php85` to the version list in `config.yaml`
- Add `php85_specific_packages` (mirrors php80–php84)
- Add changelog entry `2026.6.25-01`

Verified by building all RPMs on Rocky Linux 9; the php85 package resolves to the same dependency set as php84.

https://liquidweb.atlassian.net/browse/ENG-5436